### PR TITLE
CORS Header setzten

### DIFF
--- a/mieleGateway.js
+++ b/mieleGateway.js
@@ -35,6 +35,22 @@ function iterateToAllHrefs(obj, host, resourcePath) {
     }
 }
 
+
+app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+
+    // authorized headers for preflight requests
+    // https://developer.mozilla.org/en-US/docs/Glossary/preflight_request
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    next();
+
+    app.options('*', (req, res) => {
+        // allowed XHR methods  
+        res.header('Access-Control-Allow-Methods', 'GET, PATCH, PUT, POST, DELETE, OPTIONS');
+        res.send();
+    });
+});
+
 app.get('/init/*', function(req, response){
     if (debugLog) console.log('get: ' + req.url);
     var resourcePath = req.url;


### PR DESCRIPTION
Die Änderung setzt die CORS Einträge im Header, damit kann das Gateway von externen Webanwendungen verwendet werden.